### PR TITLE
Fix UBC errors, hide Pook shoulder holster

### DIFF
--- a/addons/a3_tweaks/CfgWeapons.hpp
+++ b/addons/a3_tweaks/CfgWeapons.hpp
@@ -25,7 +25,7 @@ class CfgWeapons {
 	HIDE_CLASS(arifle_SPAR_03_snd_F,arifle_SPAR_03_base_F);
 	HIDE_CLASS(srifle_DMR_06_hunter_F,DMR_06_hunter_base_F);
 	HIDE_CLASS(srifle_DMR_06_camo_F,DMR_06_base_F);
-	HIDE_CLASS(srifle_DMR_06_olive_F,DMR_06_base_F);
+	HIDE_CLASS(srifle_DMR_06_olive_F,srifle_DMR_06_camo_F);
 
 	class Pistol_Base_F;
 	HIDE_CLASS(hgun_Pistol_01_F,Pistol_Base_F);

--- a/addons/fwa_tweaks/CfgMagazines.hpp
+++ b/addons/fwa_tweaks/CfgMagazines.hpp
@@ -1,6 +1,6 @@
 class CfgMagazines {
-	class 150Rnd_762x51_Box;
-	class sp_fwa_50Rnd_762_mag: 150Rnd_762x51_Box {
+	class 150Rnd_762x54_Box;
+	class sp_fwa_50Rnd_762_mag: 150Rnd_762x54_Box {
 		scope = 2;
 		scopeArsenal = 2;
 	};

--- a/addons/pook_tweaks/CfgMagazines.hpp
+++ b/addons/pook_tweaks/CfgMagazines.hpp
@@ -1,11 +1,11 @@
 class CfgMagazines {
 	class CUP_6Rnd_HE_GP25_M;
-	class CUP_6Rnd_Smoke_GP25_M;
+	class CUP_6Rnd_Smoke_GP25;
 	class CUP_6Rnd_FlareWhite_GP25_M;
 	HIDE_CLASS(pook_3Rnd_FAE_GM94,CUP_6Rnd_HE_GP25_M);
-	HIDE_CLASS(pook_3Rnd_smoke_GM94,CUP_6Rnd_Smoke_GP25_M);
+	HIDE_CLASS(pook_3Rnd_smoke_GM94,CUP_6Rnd_Smoke_GP25);
 	HIDE_CLASS(pook_3Rnd_HE_GM94,CUP_6Rnd_HE_GP25_M);
 	HIDE_CLASS(pook_3Rnd_flare_GM94,CUP_6Rnd_FlareWhite_GP25_M);
-	class RPG32_F;
-	HIDE_CLASS(pook_GL_2Rnd_00_Pellets,RPG32_F);
+	class CA_Magazine;
+	HIDE_CLASS(pook_GL_2Rnd_00_Pellets,CA_Magazine);
 };

--- a/addons/pook_tweaks/CfgWeapons.hpp
+++ b/addons/pook_tweaks/CfgWeapons.hpp
@@ -5,4 +5,18 @@ class CfgWeapons {
 	HIDE_CLASS(pook_GL_GM94,CUP_glaunch_Mk13);
 	HIDE_CLASS(pook_GL_GM94_Pistol,pook_GL_RGM40_Pistol);
 	HIDE_CLASS(pook_GL_shotgun,pook_GL_Flare_Pistol);
+	HIDE_CLASS(pook_pilot_shoulderholster,ItemCore);
+
+    /*
+    // These changes may help prevent the errors that pop up with this vest, but they do not give the vest a proper texture, HIDE_CLASS is recommended instead, as used above.
+    class VestItem;
+    class ItemCore;
+    class pook_pilot_shoulderholster : ItemCore {
+        model = "\pook_h13\pook_H13\data\uniforms\shoulderholster.p3d";
+        hiddenSelectionsTextures[] = {"\pook_h13\pook_H13\data\uniforms\medic.paa"};
+        class ItemInfo : VestItem {
+            uniformModel = "\pook_h13\pook_H13\data\uniforms\shoulderholster.p3d";
+        };
+    };
+    */
 };

--- a/addons/pook_tweaks/config.cpp
+++ b/addons/pook_tweaks/config.cpp
@@ -6,7 +6,11 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "arc_cfg_main" };
+        requiredAddons[] = {
+            "arc_cfg_main",
+            "pook_GL_c",
+            "pook_H13"
+        };
         author = ARC_AUTHOR;
         VERSION_CONFIG;
     };


### PR DESCRIPTION
this fixes the following UBC errors:
```c++
Updating base class 150Rnd_762x54_Box->150Rnd_762x51_Box, by z\arc_cfg\addons\fwa_tweaks\config.bin/CfgMagazines/sp_fwa_50Rnd_762_mag/ (original sp_fwa_machinegun_core\config.bin)
Updating base class CUP_6Rnd_Smoke_GP25_M->CUP_6Rnd_Smoke_GP25, by pook_GL_c\config.bin/cfgMagazines/pook_3Rnd_smoke_GM94/ (original z\arc_cfg\addons\pook_tweaks\config.bin)
Updating base class RPG32_F->CA_Magazine, by pook_GL_c\config.bin/cfgMagazines/pook_GL_2Rnd_00_Pellets/ (original z\arc_cfg\addons\pook_tweaks\config.bin)
Updating base class srifle_DMR_06_camo_F->DMR_06_base_F, by z\arc_cfg\addons\a3_tweaks\config.bin/CfgWeapons/srifle_DMR_06_olive_F/ (original (a3\weapons_f_mark\longrangerifles\dmr_06\config.bin - no unload))
```
It also hides the `pook_pilot_shoulderholster` vest, as it has error popups for with both model and texture.
```c
Warning Message: Cannot load texture p:\pook_h13\data\uniforms\medic.paa.
 ➥ Context: ShapeLoad: N:'pook_h13\data\uniforms\shoulderholster.p3d' P:'pook_h13\data\uniforms\shoulderholster.p3d'
```