### PR TITLE
POOK - fix pook_M60_side and pook_M60_dual firemodes

### DIFF
--- a/addons/pook_tweaks/CfgWeapons.hpp
+++ b/addons/pook_tweaks/CfgWeapons.hpp
@@ -1,12 +1,17 @@
 class CfgWeapons {
-	class CUP_glaunch_Mk13;
-	class pook_GL_RGM40_Pistol;
-	class pook_GL_Flare_Pistol;
+    class CUP_glaunch_Mk13;
+    class pook_GL_RGM40_Pistol;
+    class pook_GL_Flare_Pistol;
     class ItemCore;
-	HIDE_CLASS(pook_GL_GM94,CUP_glaunch_Mk13);
-	HIDE_CLASS(pook_GL_GM94_Pistol,pook_GL_RGM40_Pistol);
-	HIDE_CLASS(pook_GL_shotgun,pook_GL_Flare_Pistol);
-	HIDE_CLASS(pook_pilot_shoulderholster,ItemCore);
+    HIDE_CLASS(pook_GL_GM94,CUP_glaunch_Mk13);
+    HIDE_CLASS(pook_GL_GM94_Pistol,pook_GL_RGM40_Pistol);
+    HIDE_CLASS(pook_GL_shotgun,pook_GL_Flare_Pistol);
+    HIDE_CLASS(pook_pilot_shoulderholster,ItemCore);
+
+    class MGun;
+    class pook_M60_side : MGun { //also fixes pook_M60_dual
+        modes[] = {"manual","close","short","medium","far"};
+    };
 
     /*
     // These changes may help prevent the errors that pop up with this vest, but they do not give the vest a proper texture, HIDE_CLASS is recommended instead, as used above.


### PR DESCRIPTION
Whoever did the config for these weapons is an idiot because despite giving them perfectly ~~questionable~~ good firemodes they went and did `modes[] = {"this"};` so the weapon was trying to use itself as it's own firemode (which is valid in arma) and meant the gunner was only firing slow single shots until you get within 100m or so when they switch to rapid single shots.

This fixes that by making the already existing firemodes accessible.