### PR TITLE
Create NIArms Tweaks

### DIFF
--- a/addons/niarms_tweaks/$PBOPREFIX$
+++ b/addons/niarms_tweaks/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\arc_cfg\addons\niarms_tweaks

--- a/addons/niarms_tweaks/CfgWeapons.hpp
+++ b/addons/niarms_tweaks/CfgWeapons.hpp
@@ -1,0 +1,15 @@
+class CfgWeapons {
+    class Rifle;
+    class Rifle_Base_F : Rifle {
+        class WeaponSlotsInfo;
+    };
+
+    class HLC_wp_M134Painless : Rifle_Base_F {
+        class WeaponSlotsInfo : WeaponSlotsInfo {
+            mass = 350; // originall 150, which is 15 lbs, way too light
+        };
+
+        ace_overheating_barrelMass = 300; // normal assumed value is 55% of weapon mass, 192.5 in the case of mass = 350. Originally would've been 82.5 based on the original mass of 150.
+        ace_overheating_closedBolt = 0; // 0 is open bolt. Releasing the trigger disconnects the delinker mechanism and any rounds that got past the delinker are fired so there are never rounds left in the chambers.
+    };
+};

--- a/addons/niarms_tweaks/config.cpp
+++ b/addons/niarms_tweaks/config.cpp
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "arc_cfg_main",
+            "hlcweapons_M134"
+        };
+        author = ARC_AUTHOR;
+        VERSION_CONFIG;
+
+        skipWhenMissingDependencies = 1;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/niarms_tweaks/script_component.hpp
+++ b/addons/niarms_tweaks/script_component.hpp
@@ -1,0 +1,6 @@
+#define COMPONENT niarms_tweaks
+#define COMPONENT_BEAUTIFIED NIArms Tweaks
+
+#include "\z\arc_cfg\addons\main\script_mod.hpp"
+#include "\z\arc_cfg\addons\main\script_macros.hpp"
+


### PR DESCRIPTION
- Create new addon
- Not sure if this should be called `niarms_tweaks` or `hlc_tweaks`, NIArms is the mod name, but classes use the older `hlc_` prefix.
- Increase NIArms minigun weight, resistance to overheating, and set to open bolt to prevent cookoffs.
- Requires #17 for `COMPONENT_NAME` macro to resolve
