### PR TITLE
Give Garand the CUP SKS reload anim

### DIFF
--- a/addons/fwa_tweaks/CfgWeapons.hpp
+++ b/addons/fwa_tweaks/CfgWeapons.hpp
@@ -1,17 +1,24 @@
 class CfgWeapons {
-	class LMG_Zafir_F;
-	class sp_fwa_machinegun_base : LMG_Zafir_F {
-		class LinkedItems
-		{
-			class LinkedItemsMuzzle
-			{
-				slot = "PointerSlot";
-				item = "sp_fwa_acc_machinegun_linkhide";
-			};
-		};
-	};
+    class LMG_Zafir_F;
+    class sp_fwa_machinegun_base : LMG_Zafir_F {
+        class LinkedItems
+        {
+            class LinkedItemsMuzzle
+            {
+                slot = "PointerSlot";
+                item = "sp_fwa_acc_machinegun_linkhide";
+            };
+        };
+    };
 
     class sp_fwa_rifle_base;
+    
+    class sp_fwa_rifle_762_base;
+
+    class sp_fwa_garand_base : sp_fwa_rifle_762_base {
+        reloadAction = "CUP_GestureReloadSKS";
+        reloadMagazineSound[] = {"\cup\weapons\CUP_Weapons_SKS\sfx\Reload.wss",1,1,35};
+    };
 
     class sp_fwa_smg_9mm_base : sp_fwa_rifle_base {
         ace_overheating_closedBolt = 0;

--- a/addons/fwa_tweaks/config.cpp
+++ b/addons/fwa_tweaks/config.cpp
@@ -9,6 +9,10 @@ class CfgPatches {
         requiredAddons[] = {
             "arc_cfg_main",
             "arc_cfg_a3_tweaks",
+            "sp_fwa_weapon_base",
+            "sp_fwa_garand",
+            "sp_fwa_machinegun_core",
+            "sp_fwa_Sterling",
             "cup_weapons_loadorder"
         };
         author = ARC_AUTHOR;


### PR DESCRIPTION
The FWA Garand currently reloads from the bottom like an M16 or AK.
Using the reload animation from the SKS in CUP looks better.
Also updated the requiredAddons to make sure the FWA pbos load first.

https://youtu.be/cYDgZwlq0Xo