### PR TITLE
Add Squad Vehicles addon

### DIFF
--- a/addons/squad_vic/$PBOPREFIX$
+++ b/addons/squad_vic/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\arc_cfg\addons\squad_vic

--- a/addons/squad_vic/CfgEventHandlers.hpp
+++ b/addons/squad_vic/CfgEventHandlers.hpp
@@ -1,0 +1,6 @@
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};

--- a/addons/squad_vic/XEH_postInit.sqf
+++ b/addons/squad_vic/XEH_postInit.sqf
@@ -1,0 +1,62 @@
+#include "script_component.hpp"
+
+if (isNil QGVAR(enabled)) then {
+    GVAR(enabled) = true;
+};
+
+if (!GVAR(enabled) || !hasInterface) exitWith {};
+
+if (isNil "diwako_dui_special_track" || {!(diwako_dui_special_track isEqualType [])}) then {
+    diwako_dui_special_track = [];
+};
+
+if (isNil QGVAR(list)) then {
+    GVAR(list) = [];
+} else {
+    for "_i" from 0 to ((count GVAR(list)) - 1) do {
+        private _entry = GVAR(list) select _i;
+        if (count _entry % 2 != 0) exitWith {
+            private _message = format ["Warning: Squad Vics list has bad entry at %1, it must be [SQUAD, VEHICLE], %2", _i, _entry];
+            diag_log _message;
+            systemChat _message;
+        };
+
+        private _squad = _entry select 0;
+        if (group ace_player == _squad) exitWith {
+            GVAR(currentVic) = _entry select 1;
+            diwako_dui_special_track pushBackUnique GVAR(currentVic);
+        };
+    };
+};
+
+private _conditionSquadVicAdd = {GVAR(enabled) && {!(_target in diwako_dui_special_track)}};
+private _statementSquadVicAdd = {
+    if !(isNil QGVAR(currentVic)) then {
+        private _currentVicIndex = diwako_dui_special_track find GVAR(currentVic);
+        if (_currentVicIndex >= 0) exitWith {
+            diwako_dui_special_track deleteAt _currentVicIndex;
+        };
+    };
+
+    GVAR(currentVic) = _target ;
+    diwako_dui_special_track pushBackUnique _target ;
+};
+private _actionSquadVicAdd = ["Set as Squad Vehicle", "Set as Squad Vehicle", "", _statementSquadVicAdd, _conditionSquadVicAdd] call ace_interact_menu_fnc_createAction;
+{
+    [_x, 0, ["ACE_MainActions"], _actionSquadVicAdd, true] call ace_interact_menu_fnc_addActionToClass;
+    [_x, 1, ["ACE_SelfActions"], _actionSquadVicAdd, true] call ace_interact_menu_fnc_addActionToClass;
+} forEach ["LandVehicle", "Air", "Ship"];
+
+private _conditionSquadVicRemove = {GVAR(enabled) && {!(isNil QGVAR(currentVic))} && {_target == GVAR(currentVic)}};
+private _statementSquadVicRemove = {
+    private _currentVicIndex = diwako_dui_special_track find GVAR(currentVic) ;
+    if (_currentVicIndex >= 0) exitWith {
+        diwako_dui_special_track deleteAt _currentVicIndex;
+        GVAR(currentVic) = nil;
+    };
+};
+private _actionSquadVicRemove = ["Remove as Squad Vehicle", "Remove as Squad Vehicle", "", _statementSquadVicRemove, _conditionSquadVicRemove] call ace_interact_menu_fnc_createAction;
+{
+    [_x, 0, ["ACE_MainActions"], _actionSquadVicRemove, true] call ace_interact_menu_fnc_addActionToClass;
+    [_x, 1, ["ACE_SelfActions"], _actionSquadVicRemove, true] call ace_interact_menu_fnc_addActionToClass;
+} forEach ["LandVehicle", "Air", "Ship"];

--- a/addons/squad_vic/config.cpp
+++ b/addons/squad_vic/config.cpp
@@ -1,0 +1,15 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"arc_cfg_main"};
+        author = ARC_AUTHOR;
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/squad_vic/script_component.hpp
+++ b/addons/squad_vic/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT squad_vic
+#define COMPONENT_BEAUTIFIED Squad Vehicle
+#include "\z\arc_cfg\addons\main\script_mod.hpp"
+#include "\z\arc_cfg\addons\main\script_macros.hpp"

--- a/addons/squad_vic/squad_vics.inc.sqf
+++ b/addons/squad_vic/squad_vics.inc.sqf
@@ -3,11 +3,12 @@
 // This array assigns vehicles to squads
 // Each assignment should consist of an array that contains the variable name of the group, and the variable name of the vehicle, [SQUAD, VEHICLE].
 // Only one vehicle can be assigned per squad.
-squadVic_List = [];
+// This should be placed in init.sqf
+arc_cfg_squad_vic_list = [];
 
 /*
 Example:
-squadVic_List = [
+arc_cfg_squad_vic_list = [
     [BritSquadHQ, BritTruckHQ],
     [BritSquad10, BritTruck10],
     [BritSquad11, BritTruck11],
@@ -20,3 +21,6 @@ squadVic_List = [
     [BritCrew, BritTank]
 ];
 */
+
+// If you want to disable the system place this in init.sqf
+arc_cfg_squad_vic_enabled = false;

--- a/addons/squad_vic/squad_vics.inc.sqf
+++ b/addons/squad_vic/squad_vics.inc.sqf
@@ -1,0 +1,22 @@
+// This adds an icon to the DUI HUD compass for the vehicle assigned to each squad.
+
+// This array assigns vehicles to squads
+// Each assignment should consist of an array that contains the variable name of the group, and the variable name of the vehicle, [SQUAD, VEHICLE].
+// Only one vehicle can be assigned per squad.
+squadVic_List = [];
+
+/*
+Example:
+squadVic_List = [
+    [BritSquadHQ, BritTruckHQ],
+    [BritSquad10, BritTruck10],
+    [BritSquad11, BritTruck11],
+    [BritSquad12, BritTruck12],
+    [BritSquad13, BritTruck13],
+    [BritSquad20, BritTruck20],
+    [BritSquad21, BritTruck21],
+    [BritSquad22, BritTruck22],
+    [BritSquad23, BritTruck23],
+    [BritCrew, BritTank]
+];
+*/


### PR DESCRIPTION
Adds an icon for the assigned vehicle of a squad to the DUI HUD compass of each member of the squad.
A vehicle can be assigned by script, or by ace interaction, and removed by ace interaction.

The scripted method should be used in `init.sqf`, where each entry in the array is a an array of the variable name of the group, and the variable name of the vehicle, [SQUAD, VEHICLE].
Example:
```sqf
arc_cfg_squad_vic_list = [
    [BritSquadHQ, BritTruckHQ],
    [BritSquad10, BritTruck10],
    [BritSquad11, BritTruck11],
    [BritSquad12, BritTruck12],
    [BritSquad13, BritTruck13],
    [BritCrew, BritTank]
];
```

The system can also be disabled by putting `arc_cfg_squad_vic_enabled = false;` in init.sqf if the mission maker doesn't want to use it.

<img width="718" height="419" alt="f65fad308fbbbdebb0e4adb4741ea6ea" src="https://github.com/user-attachments/assets/2403f362-a33f-447f-bacb-0295234090d5" />
<img width="671" height="495" alt="873de98565967e40013677f1a77c4655" src="https://github.com/user-attachments/assets/fbbb3d60-6be4-43d9-919b-15e125e57bb8" />
<img width="746" height="511" alt="7c450a9dad7e0ae5aa864b702862c9f8" src="https://github.com/user-attachments/assets/a490941b-01f9-499d-8c04-04ea7dc9048e" />
