### PR TITLE
fix wrs_firearms_tweaks PBOPREFIX

### DIFF
--- a/addons/wrs_firearms_tweaks/$PBOPREFIX$
+++ b/addons/wrs_firearms_tweaks/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\arc_cfg\addons\wrs_firearm_tweaks
+z\arc_cfg\addons\wrs_firearms_tweaks


### PR DESCRIPTION
Somehow the S in firearms got dropped in the pboprefix